### PR TITLE
Support Tracker Programs as output and support writing in different DEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are three types of logger output:
     ```typescript
     import { initLogger } from "@eyeseetea/d2-logger";
 
-    const logger = await initLogger<string>({
+    const logger = await initLogger({
         type: "program",
         debug: true,
         baseUrl: "https://play.dhis2.org/40.2.2",
@@ -49,7 +49,7 @@ There are three types of logger output:
     ```typescript
     import { initLogger } from "@eyeseetea/d2-logger";
 
-    const logger = await initLogger<string>({
+    const logger = await initLogger({
         type: "console",
     });
     ```
@@ -71,9 +71,9 @@ There are three types of logger output:
     Therefore, the following configuration will be passed to the logger:
 
     ```typescript
-    import { initLogger, TrackerProgramContent } from "@eyeseetea/d2-logger";
+    import { initLogger } from "@eyeseetea/d2-logger";
 
-    const logger = await initLogger<TrackerProgramContent>({
+    const logger = await initLogger({
         type: "trackerProgram",
         debug: true,
         baseUrl: "https://play.dhis2.org/40.2.2",

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ There are three types of logger output:
 
 3. Using a DHIS2 tracker program to register the logs as events:
 
-    You will need to have and existing tracker program in DHIS2 with the following data elements with value type Text: Message and MessageType. MessageType would be and option set with the following options: "Error", "Warn", "Success", "Info" and "Debug".
+    You will need to have and existing tracker program in DHIS2. In order to be able to log the log type (Error", "Warn", "Success", "Info" and "Debug") in the event, it would be necessary to create a data element and assign it to the program stages, and then add this data element id to the configuration.
 
     Therefore, the following configuration will be passed to the logger:
 
@@ -79,7 +79,7 @@ There are three types of logger output:
         baseUrl: "https://play.dhis2.org/40.2.2",
         auth: "admin:district",
         trackerProgramId: "", // Tracker program Id where register the logs as events
-        messageTypeId: "", // Id of the data element which is the types of message
+        messageTypeId: "", // Id of the data element which is the types of log
     });
     ```
 
@@ -87,7 +87,7 @@ There are three types of logger output:
 
     - Please note that `auth` is not mandatory if it's used in the DHIS2 app instead of in a script.
     - If `debug` is `true`, then in addition to registering the logs in the DHIS2 program, they will also be displayed on the console.
-    - `messageTypeId` is not mandatory. If the message type is not provided, "Error", "Warn", "Success", "Info" and "Debug" will not be logged in the tracker program.
+    - `messageTypeId` is not mandatory. If the log type is not provided, "Error", "Warn", "Success", "Info" and "Debug" will not be logged in the event.
 
     To log messages:
 
@@ -167,6 +167,11 @@ There are three types of logger output:
         ],
     });
     ```
+
+    Notice:
+
+    - `messages` is an array of objects with the id of the Data Element and a string value. These would be created as Data Values in the event.
+    - `eventStatus` is not mandatory. By deafult "ACTIVE" will be the default status of the event.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,30 @@
 # d2-logger
 
-DHIS2 library that allows a certain application to register logs as events in a DHIS2 program or display logs on the console.
+DHIS2 library that allows a certain application to register logs as events in a DHIS2 event program, tracker program or simply display logs on the console.
 
 ## Usage
 
-There are two types of logger output:
+There are three types of logger output:
 
-1. Using a DHIS2 events program to register the logs:
+1. Using a DHIS2 events program to register the logs as events:
 
     You will need to have and existing event program in DHIS2 with the following data elements with value type Text: Message and MessageType. MessageType would be and option set with the following options: "Error", "Warn", "Success", "Info" and "Debug".
 
     Therefore, the following configuration will be passed to the logger:
 
     ```typescript
-    import { Logger } from "@eyeseetea/d2-logger";
+    import { initLogger } from "@eyeseetea/d2-logger";
 
-    const logger = new Logger();
-
-    await logger.init({
+    const logger = await initLogger<string>({
         type: "program",
         debug: true,
         baseUrl: "https://play.dhis2.org/40.2.2",
         auth: "admin:district",
-        organisationUnitId: "H8RixfF8ugH",
-        programId: "zARxYmOD18Z",
+        organisationUnitId: "", // Organisation unit Id where the program is registered
+        programId: "", // Event program Id where register the logs as events
         dataElements: {
-            messageId: "BjUzF5E4eR8",
-            messageTypeId: "NpS5LoLuhgS",
+            messageId: "", // Id of the data element which is the message
+            messageTypeId: "", // Id of the data element which is the types of message
         },
     });
     ```
@@ -36,27 +34,134 @@ There are two types of logger output:
     - Please note that `auth` is not mandatory if it's used in the DHIS2 app instead of in a script.
     - If `debug` is `true`, then in addition to registering the logs in the DHIS2 program, they will also be displayed on the console.
 
+    To log messages:
+
+    ```typescript
+    logger.debug("This is a Debug message");
+    logger.info("This is an Info message");
+    logger.success("This is a Success message");
+    logger.warn("This is a Warn message");
+    logger.error("This is an Error message");
+    ```
+
 2. Displaying the logs only in the console:
 
     ```typescript
-    import { Logger } from "@eyeseetea/d2-logger";
+    import { initLogger } from "@eyeseetea/d2-logger";
 
-    const logger = new Logger();
-
-    logger.init({
+    const logger = await initLogger<string>({
         type: "console",
     });
     ```
 
-To log messages:
+    To log messages:
 
-```typescript
-logger.debug("This is a Debug message");
-logger.info("This is an Info message");
-logger.success("This is a Success message");
-logger.warn("This is a Warn message");
-logger.error("This is an Error message");
-```
+    ```typescript
+    logger.debug("This is a Debug message");
+    logger.info("This is an Info message");
+    logger.success("This is a Success message");
+    logger.warn("This is a Warn message");
+    logger.error("This is an Error message");
+    ```
+
+3. Using a DHIS2 tracker program to register the logs as events:
+
+    You will need to have and existing tracker program in DHIS2 with the following data elements with value type Text: Message and MessageType. MessageType would be and option set with the following options: "Error", "Warn", "Success", "Info" and "Debug".
+
+    Therefore, the following configuration will be passed to the logger:
+
+    ```typescript
+    import { initLogger, TrackerProgramContent } from "@eyeseetea/d2-logger";
+
+    const logger = await initLogger<TrackerProgramContent>({
+        type: "trackerProgram",
+        debug: true,
+        baseUrl: "https://play.dhis2.org/40.2.2",
+        auth: "admin:district",
+        trackerProgramId: "", // Tracker program Id where register the logs as events
+        messageTypeId: "", // Id of the data element which is the types of message
+    });
+    ```
+
+    Notice:
+
+    - Please note that `auth` is not mandatory if it's used in the DHIS2 app instead of in a script.
+    - If `debug` is `true`, then in addition to registering the logs in the DHIS2 program, they will also be displayed on the console.
+    - `messageTypeId` is not mandatory. If the message type is not provided, "Error", "Warn", "Success", "Info" and "Debug" will not be logged in the tracker program.
+
+    To log messages:
+
+    ```typescript
+    logger.debug({
+        config: {
+            trackedEntityId: "", // Tracked entity Id where register the logs as events
+            programStageId: "", // Program Stage Id where register the logs as events
+            enrollmentId: "", // Enrollment Id where register the logs as events
+        },
+        messages: [
+            {
+                id: "", // Data Element Id of the Data Value of the event to be logged
+                value: "This is a Debug message",
+            },
+        ],
+    });
+
+    logger.info({
+        config: {
+            trackedEntityId: "", // Tracked entity Id where register the logs as events
+            programStageId: "", // Program Stage Id where register the logs as events
+            enrollmentId: "", // Enrollment Id where register the logs as events
+        },
+        messages: [
+            {
+                id: "", // Data Element Id of the Data Value of the event to be logged
+                value: "This is an Info message",
+            },
+        ],
+    });
+
+    logger.success({
+        config: {
+            trackedEntityId: "", // Tracked entity Id where register the logs as events
+            programStageId: "", // Program Stage Id where register the logs as events
+            enrollmentId: "", // Enrollment Id where register the logs as events
+        },
+        messages: [
+            {
+                id: "", // Data Element Id of the Data Value of the event to be logged
+                value: "This is a Success message",
+            },
+        ],
+    });
+
+    logger.warn({
+        config: {
+            trackedEntityId: "", // Tracked entity Id where register the logs as events
+            programStageId: "", // Program Stage Id where register the logs as events
+            enrollmentId: "", // Enrollment Id where register the logs as events
+        },
+        messages: [
+            {
+                id: "", // Data Element Id of the Data Value of the event to be logged
+                value: "This is a Warn message",
+            },
+        ],
+    });
+
+    logger.error({
+        config: {
+            trackedEntityId: "", // Tracked entity Id where register the logs as events
+            programStageId: "", // Program Stage Id where register the logs as events
+            enrollmentId: "", // Enrollment Id where register the logs as events
+        },
+        messages: [
+            {
+                id: "", // Data Element Id of the Data Value of the event to be logged
+                value: "This is an Error message",
+            },
+        ],
+    });
+    ```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ There are three types of logger output:
             trackedEntityId: "", // Tracked entity Id where register the logs as events
             programStageId: "", // Program Stage Id where register the logs as events
             enrollmentId: "", // Enrollment Id where register the logs as events
+            eventStatus: "", // event status by default is "ACTIVE" if not specified, but it can also be "COMPLETED", "VISITED", "SCHEDULE", "OVERDUE" or "SKIPPED"
         },
         messages: [
             {
@@ -111,6 +112,7 @@ There are three types of logger output:
             trackedEntityId: "", // Tracked entity Id where register the logs as events
             programStageId: "", // Program Stage Id where register the logs as events
             enrollmentId: "", // Enrollment Id where register the logs as events
+            eventStatus: "", // event status by default is "ACTIVE" if not specified, but it can also be "COMPLETED", "VISITED", "SCHEDULE", "OVERDUE" or "SKIPPED"
         },
         messages: [
             {
@@ -125,6 +127,7 @@ There are three types of logger output:
             trackedEntityId: "", // Tracked entity Id where register the logs as events
             programStageId: "", // Program Stage Id where register the logs as events
             enrollmentId: "", // Enrollment Id where register the logs as events
+            eventStatus: "", // event status by default is "ACTIVE" if not specified, but it can also be "COMPLETED", "VISITED", "SCHEDULE", "OVERDUE" or "SKIPPED"
         },
         messages: [
             {
@@ -139,6 +142,7 @@ There are three types of logger output:
             trackedEntityId: "", // Tracked entity Id where register the logs as events
             programStageId: "", // Program Stage Id where register the logs as events
             enrollmentId: "", // Enrollment Id where register the logs as events
+            eventStatus: "", // event status by default is "ACTIVE" if not specified, but it can also be "COMPLETED", "VISITED", "SCHEDULE", "OVERDUE" or "SKIPPED"
         },
         messages: [
             {
@@ -153,6 +157,7 @@ There are three types of logger output:
             trackedEntityId: "", // Tracked entity Id where register the logs as events
             programStageId: "", // Program Stage Id where register the logs as events
             enrollmentId: "", // Enrollment Id where register the logs as events
+            eventStatus: "", // event status by default is "ACTIVE" if not specified, but it can also be "COMPLETED", "VISITED", "SCHEDULE", "OVERDUE" or "SKIPPED"
         },
         messages: [
             {

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ There are three types of logger output:
     Therefore, the following configuration will be passed to the logger:
 
     ```typescript
-    import { initLogger } from "@eyeseetea/d2-logger";
+    import { initLogger, ProgramLogger } from "@eyeseetea/d2-logger";
 
-    const logger = await initLogger({
+    const logger: ProgramLogger = await initLogger({
         type: "program",
         debug: true,
         baseUrl: "https://play.dhis2.org/40.2.2",
@@ -47,9 +47,9 @@ There are three types of logger output:
 2. Displaying the logs only in the console:
 
     ```typescript
-    import { initLogger } from "@eyeseetea/d2-logger";
+    import { initLogger, ConsoleLogger } from "@eyeseetea/d2-logger";
 
-    const logger = await initLogger({
+    const logger: ConsoleLogger = await initLogger({
         type: "console",
     });
     ```
@@ -71,9 +71,9 @@ There are three types of logger output:
     Therefore, the following configuration will be passed to the logger:
 
     ```typescript
-    import { initLogger } from "@eyeseetea/d2-logger";
+    import { initLogger, TrackerProgramLogger } from "@eyeseetea/d2-logger";
 
-    const logger = await initLogger({
+    const logger: TrackerProgramLogger = await initLogger({
         type: "trackerProgram",
         debug: true,
         baseUrl: "https://play.dhis2.org/40.2.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "release": "bash scripts/publish.sh",
         "test": "vitest",
         "script-program-example": "npx ts-node src/scripts/index.ts programLogger log",
-        "script-console-example": "npx ts-node src/scripts/index.ts consoleLogger log"
+        "script-console-example": "npx ts-node src/scripts/index.ts consoleLogger log",
+        "script-tracker-program-example": "npx ts-node src/scripts/index.ts trackerProgramLogger log"
     },
     "dependencies": {
         "@babel/runtime": "^7.5.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@eyeseetea/d2-logger",
-    "version": "0.1.1",
-    "description": "DHIS2 library that allows a certain application to register events in a DHIS2 program",
+    "version": "1.0.0",
+    "description": "DHIS2 library that allows a certain application to register logs as events in a DHIS2 event program, tracker program or simply display logs on the console.",
     "author": "EyeSeeTea team <info@eyeseetea.com>",
     "license": "GPL-3.0",
     "repository": {

--- a/src/data/repositories/ConsoleLoggerRepository.ts
+++ b/src/data/repositories/ConsoleLoggerRepository.ts
@@ -1,10 +1,10 @@
 import { FutureData } from "../../data/api-futures";
 import { Future } from "../../domain/entities/generic/Future";
-import { Log } from "../../domain/entities/Log";
+import { DefaultLog } from "../../domain/entities/Log";
 import { LoggerRepository } from "../../domain/repositories/LoggerRepository";
 
 export class ConsoleLoggerRepository implements LoggerRepository {
-    log(log: Log): FutureData<void> {
+    log(log: DefaultLog): FutureData<void> {
         const { message, messageType } = log;
         const date = new Date().toISOString();
         process.stderr.write(`[${messageType.toUpperCase()}] [${date}] ${message}\n`);

--- a/src/data/repositories/ProgramD2Repository.ts
+++ b/src/data/repositories/ProgramD2Repository.ts
@@ -49,7 +49,10 @@ export class ProgramD2Repository implements ProgramRepository {
                     messageDataElement?.valueType === "TEXT" ||
                     messageDataElement?.valueType === "LONG_TEXT";
 
-                const isMessageTypeDataElementOk = !!messageTypeDataElement?.optionSetValue;
+                const isMessageTypeDataElementOk =
+                    !!messageTypeDataElement?.optionSetValue ||
+                    messageDataElement?.valueType === "TEXT" ||
+                    messageDataElement?.valueType === "LONG_TEXT";
 
                 return Future.success(
                     response.objects[0]?.id === programId &&

--- a/src/data/repositories/ProgramLoggerD2Repository.ts
+++ b/src/data/repositories/ProgramLoggerD2Repository.ts
@@ -2,7 +2,7 @@ import { D2Api, MetadataPick, D2TrackerEvent, DataValue } from "../../types/d2-a
 import { apiToFuture, FutureData } from "../api-futures";
 import { Future } from "../../domain/entities/generic/Future";
 import { Id } from "../../domain/entities/Base";
-import { Log } from "../../domain/entities/Log";
+import { DefaultLog } from "../../domain/entities/Log";
 import { ProgramLoggerConfig } from "../../domain/entities/LoggerConfig";
 import { LoggerRepository } from "../../domain/repositories/LoggerRepository";
 
@@ -27,7 +27,7 @@ export class ProgramLoggerD2Repository implements LoggerRepository {
         this.organisationUnitId = organisationUnitId;
     }
 
-    log(log: Log): FutureData<void> {
+    log(log: DefaultLog): FutureData<void> {
         return this.getProgramStage().flatMap(programStage => {
             const d2EventProgram = this.mapLogToD2EventProgam({
                 log,
@@ -86,7 +86,7 @@ export class ProgramLoggerD2Repository implements LoggerRepository {
     }
 
     private mapLogToD2EventProgam(params: {
-        log: Log;
+        log: DefaultLog;
         programId: Id;
         organisationUnitId: Id;
         messageId: Id;
@@ -113,7 +113,7 @@ export class ProgramLoggerD2Repository implements LoggerRepository {
     }
 
     private getDataValuesFromLog(params: {
-        log: Log;
+        log: DefaultLog;
         messageId: Id;
         messageTypeId: Id;
         programStage: D2ProgramStage;
@@ -124,7 +124,7 @@ export class ProgramLoggerD2Repository implements LoggerRepository {
             ({ dataElement }) => dataElement.id === messageTypeId
         )?.dataElement;
         const messageTypeDataValue =
-            messageTypeDataElement?.optionSet.options.find(
+            messageTypeDataElement?.optionSet?.options.find(
                 option => option.name === log.messageType || option.code === log.messageType
             )?.code || log.messageType;
 

--- a/src/data/repositories/TrackerProgramD2Repository.ts
+++ b/src/data/repositories/TrackerProgramD2Repository.ts
@@ -1,0 +1,34 @@
+import { D2Api } from "../../types/d2-api";
+import { apiToFuture, FutureData } from "../../data/api-futures";
+import { Future } from "../../domain/entities/generic/Future";
+import { TrackerProgramLoggerConfig } from "../../domain/entities/LoggerConfig";
+import { ProgramRepository } from "../../domain/repositories/ProgramRepository";
+
+export class TrackerProgramD2Repository implements ProgramRepository {
+    checkConfig(config: TrackerProgramLoggerConfig): FutureData<boolean> {
+        const { baseUrl, auth, trackerProgramId } = config;
+
+        const d2Api = new D2Api({ baseUrl: baseUrl, auth: auth });
+
+        return apiToFuture(
+            d2Api.models.programs.get({
+                fields: trackerProgramFields,
+                filter: { id: { eq: trackerProgramId } },
+            })
+        ).flatMap(response => {
+            if (response?.objects[0]?.id) {
+                return Future.success(response.objects[0]?.id === trackerProgramId);
+            } else {
+                return Future.error(
+                    new Error(
+                        `Tracker program with id ${trackerProgramId} not found. Logger not initialized`
+                    )
+                );
+            }
+        });
+    }
+}
+
+const trackerProgramFields = {
+    id: true,
+} as const;

--- a/src/data/repositories/TrackerProgramLoggerD2Repository.ts
+++ b/src/data/repositories/TrackerProgramLoggerD2Repository.ts
@@ -1,0 +1,189 @@
+import { EventStatus } from "@eyeseetea/d2-api";
+import { D2Api, MetadataPick, D2TrackerEvent, DataValue } from "../../types/d2-api";
+import { apiToFuture, FutureData } from "../api-futures";
+import { Future } from "../../domain/entities/generic/Future";
+import { Id } from "../../domain/entities/Base";
+import { TrackerProgramLog, MessageType, TrackerProgramMessages } from "../../domain/entities/Log";
+import { TrackerProgramLoggerConfig } from "../../domain/entities/LoggerConfig";
+import { LoggerRepository } from "../../domain/repositories/LoggerRepository";
+
+const IMPORT_STRATEGY_CREATE = "CREATE";
+const TRACKER_IMPORT_JOB = "TRACKER_IMPORT_JOB";
+const TRACKER_EVENT_DEFAULT_STATUS = "ACTIVE";
+const TRACKER_ORG_UNIT_ALL_MODE = "ALL";
+
+export class TrackerProgramLoggerD2Repository implements LoggerRepository {
+    api: D2Api;
+    trackerProgramId: Id;
+    messageTypeId: Id | undefined;
+
+    constructor(config: TrackerProgramLoggerConfig) {
+        const { baseUrl, auth, trackerProgramId, messageTypeId } = config;
+
+        this.api = new D2Api({ baseUrl: baseUrl, auth: auth });
+        this.trackerProgramId = trackerProgramId;
+        this.messageTypeId = messageTypeId;
+    }
+
+    log(log: TrackerProgramLog): FutureData<void> {
+        const { programStageId, trackedEntityId, enrollmentId } = log.config;
+        return Future.joinObj({
+            programStage: this.getProgramStage(programStageId),
+            organisationUnitId: this.getOrganisationUnitId(trackedEntityId, enrollmentId),
+        }).flatMap(({ programStage, organisationUnitId }) => {
+            const d2TrackerEvents = this.mapLogToD2TrackerEvents(
+                log,
+                programStage,
+                organisationUnitId
+            );
+            return this.postApiTracker(d2TrackerEvents);
+        });
+    }
+
+    private getProgramStage(programStageId: Id): FutureData<D2ProgramStage> {
+        return apiToFuture(
+            this.api.models.programStages.get({
+                fields: programStageFields,
+                filter: { id: { eq: programStageId } },
+            })
+        ).flatMap(response => {
+            const programStage = response.objects[0];
+            if (programStage) {
+                return Future.success(programStage);
+            } else {
+                return Future.error(
+                    new Error(
+                        `Program stage with id ${programStageId} from program id ${this.trackerProgramId} not found`
+                    )
+                );
+            }
+        });
+    }
+
+    private getOrganisationUnitId(trackedEntity: Id, enrollmentId: Id): FutureData<Id> {
+        return apiToFuture(
+            this.api.tracker.enrollments.get({
+                ouMode: TRACKER_ORG_UNIT_ALL_MODE,
+                fields: { orgUnit: true },
+                program: this.trackerProgramId,
+                trackedEntity: trackedEntity,
+                enrollment: enrollmentId,
+            })
+        ).flatMap(response => {
+            const orgUnitId = response.instances[0]?.orgUnit;
+            if (orgUnitId) {
+                return Future.success(orgUnitId);
+            } else {
+                return Future.error(
+                    new Error(
+                        `Organisation unit id in enrollment id ${enrollmentId} in trackedEntity id ${trackedEntity} from program id ${this.trackerProgramId} not found`
+                    )
+                );
+            }
+        });
+    }
+
+    private mapLogToD2TrackerEvents(
+        log: TrackerProgramLog,
+        programStage: D2ProgramStage,
+        organisationUnitId: Id
+    ): D2TrackerEvent[] {
+        const { programStageId, trackedEntityId, enrollmentId, eventStatus } = log.config;
+        const dataValues = this.getDataValuesFromLog(programStage, log.messages, log.messageType);
+        return [
+            {
+                event: "",
+                status:
+                    (eventStatus as EventStatus) || (TRACKER_EVENT_DEFAULT_STATUS as EventStatus), // TODO: remove once d2-api EventStatus has SCHEDULE
+                program: this.trackerProgramId,
+                programStage: programStageId,
+                enrollment: enrollmentId,
+                trackedEntity: trackedEntityId,
+                orgUnit: organisationUnitId,
+                occurredAt: new Date().toISOString(),
+                dataValues: dataValues,
+            },
+        ];
+    }
+
+    private getDataValuesFromLog(
+        programStage: D2ProgramStage,
+        messages: TrackerProgramMessages[],
+        messageType: MessageType
+    ): DataValue[] {
+        const messageTypeDataElement = programStage.programStageDataElements.find(
+            ({ dataElement }) => dataElement.id === this.messageTypeId
+        )?.dataElement;
+
+        const messageTypeDataValue =
+            messageTypeDataElement?.optionSet?.options.find(
+                option => option.name === messageType || option.code === messageType
+            )?.code || messageType;
+
+        const dataValues: DataValue[] =
+            this.messageTypeId && messageTypeDataElement
+                ? [
+                      {
+                          dataElement: this.messageTypeId,
+                          value: messageTypeDataValue,
+                      },
+                  ]
+                : [];
+
+        return messages.reduce(
+            (acc: DataValue[], message: TrackerProgramMessages): DataValue[] => [
+                ...acc,
+                {
+                    dataElement: message.id,
+                    value: message.value,
+                },
+            ],
+            dataValues
+        );
+    }
+
+    private postApiTracker(d2TrackerEvents: D2TrackerEvent[]): FutureData<void> {
+        return apiToFuture(
+            this.api.tracker.postAsync(
+                {
+                    importStrategy: IMPORT_STRATEGY_CREATE,
+                    skipRuleEngine: true,
+                },
+                { events: d2TrackerEvents }
+            )
+        ).flatMap(response => {
+            return apiToFuture(
+                this.api.system.waitFor(TRACKER_IMPORT_JOB, response.response.id)
+            ).flatMap(result => {
+                if (result && result.status !== "ERROR") {
+                    return Future.success(undefined);
+                } else {
+                    return Future.error(
+                        new Error(
+                            `Error: ${result?.validationReport?.errorReports?.at(0)?.message} `
+                        )
+                    );
+                }
+            });
+        });
+    }
+}
+
+const programStageFields = {
+    id: true,
+    programStageDataElements: {
+        dataElement: {
+            id: true,
+            code: true,
+            valueType: true,
+            optionSetValue: true,
+            optionSet: { options: { name: true, code: true } },
+        },
+    },
+} as const;
+
+type D2ProgramStage = MetadataPick<{
+    programStages: {
+        fields: typeof programStageFields;
+    };
+}>["programStages"][number];

--- a/src/domain/entities/Log.ts
+++ b/src/domain/entities/Log.ts
@@ -1,6 +1,28 @@
-export type Log = {
+import { Id } from "./Base";
+
+export type Log = DefaultLog | TrackerProgramLog;
+
+export type DefaultLog = {
     message: string;
     messageType: MessageType;
 };
 
 export type MessageType = "Debug" | "Info" | "Success" | "Warn" | "Error";
+
+export type TrackerProgramLog = {
+    config: TrackerProgramMessageConfig;
+    messageType: MessageType;
+    messages: TrackerProgramMessages[];
+};
+
+export type TrackerProgramMessageConfig = {
+    trackedEntityId: Id;
+    programStageId: Id;
+    enrollmentId: Id;
+    eventStatus?: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+};
+
+export type TrackerProgramMessages = {
+    id: Id;
+    value: string;
+};

--- a/src/domain/entities/LoggerConfig.ts
+++ b/src/domain/entities/LoggerConfig.ts
@@ -5,7 +5,7 @@ interface LoggerConfigBase {
     debug?: boolean;
 }
 
-export type LoggerConfig = ProgramLoggerConfig | ConsoleLoggerConfig;
+export type LoggerConfig = ProgramLoggerConfig | ConsoleLoggerConfig | TrackerProgramLoggerConfig;
 
 export interface ConsoleLoggerConfig extends LoggerConfigBase {
     type: "console";
@@ -29,3 +29,11 @@ export type DataElements = {
     messageId: Id;
     messageTypeId: Id;
 };
+
+export interface TrackerProgramLoggerConfig extends LoggerConfigBase {
+    type: "trackerProgram";
+    baseUrl: string;
+    auth: Maybe<Auth>;
+    trackerProgramId: Id;
+    messageTypeId: Maybe<Id>;
+}

--- a/src/domain/repositories/LoggerRepository.ts
+++ b/src/domain/repositories/LoggerRepository.ts
@@ -2,5 +2,5 @@ import { FutureData } from "../../data/api-futures";
 import { Log } from "../../domain/entities/Log";
 
 export interface LoggerRepository {
-    log(log: Log, options?: { isDebug: boolean }): FutureData<void>;
+    log(log: Log): FutureData<void>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,14 +29,23 @@ export interface Logger<T> {
     error(content: T): Promise<void>;
 }
 
-export async function initLogger<T>(config: LoggerConfig): Promise<Logger<T>> {
+type LoggerType = {
+    program: ProgramLogger;
+    trackerProgram: TrackerProgramLogger;
+    console: ConsoleLogger;
+};
+
+export async function initLogger<Config extends LoggerConfig>(
+    config: Config
+): Promise<LoggerType[Config["type"]]> {
+    type Result = Promise<LoggerType[Config["type"]]>;
+
     switch (config.type) {
         case "program":
-            return ProgramLogger.create(config) as Promise<Logger<T>>;
+            return ProgramLogger.create(config) as Result;
         case "trackerProgram":
-            return TrackerProgramLogger.create(config) as Promise<Logger<T>>;
+            return TrackerProgramLogger.create(config) as Result;
         case "console":
-        default:
-            return ConsoleLogger.create() as Promise<Logger<T>>;
+            return ConsoleLogger.create() as Result;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,76 +1,42 @@
-import { ProgramLoggerD2Repository } from "./data/repositories/ProgramLoggerD2Repository";
-import { ConsoleLoggerRepository } from "./data/repositories/ConsoleLoggerRepository";
-import { LoggerConfig, ProgramLoggerConfig } from "./domain/entities/LoggerConfig";
-import { MessageType } from "./domain/entities/Log";
-import { CheckConfigProgramLoggerUseCase } from "./domain/usecases/CheckConfigProgramLoggerUseCase";
-import { LogMessageUseCase } from "./domain/usecases/LogMessageUseCase";
-import { LoggerRepository } from "./domain/repositories/LoggerRepository";
-import { ProgramRepository } from "./domain/repositories/ProgramRepository";
-import { ProgramD2Repository } from "./data/repositories/ProgramD2Repository";
+import { Id } from "./domain/entities/Base";
+import { LoggerConfig } from "./domain/entities/LoggerConfig";
+import { ConsoleLogger } from "./loggers/ConsoleLogger";
+import { ProgramLogger } from "./loggers/ProgramLogger";
+import { TrackerProgramLogger } from "./loggers/TrackerProgramLogger";
 
-export class Logger {
-    isDebug: boolean | undefined;
-    programRepository: ProgramRepository | undefined;
-    loggerRepository: LoggerRepository | undefined;
+export type TrackerProgramContent = {
+    config: TrackerProgramMessageConfig;
+    messages: TrackerProgramMessages[];
+};
 
-    async init(config: LoggerConfig): Promise<void> {
-        this.isDebug = config.debug ?? false;
-        switch (config.type) {
-            case "program":
-                return await this.configProgramLogger(config);
-            case "console":
-                return this.configConsoleLogger();
-            default:
-                return await this.configProgramLogger(config);
-        }
-    }
+type TrackerProgramMessageConfig = {
+    trackedEntityId: Id;
+    programStageId: Id;
+    enrollmentId: Id;
+    eventStatus?: "ACTIVE" | "COMPLETED" | "VISITED" | "SCHEDULE" | "OVERDUE" | "SKIPPED";
+};
 
-    debug(message: string): Promise<void> {
-        return this.log(message, "Debug");
-    }
+type TrackerProgramMessages = {
+    id: Id;
+    value: string;
+};
 
-    info(message: string): Promise<void> {
-        return this.log(message, "Info");
-    }
+export interface Logger<T> {
+    debug(content: T): Promise<void>;
+    info(content: T): Promise<void>;
+    success(content: T): Promise<void>;
+    warn(content: T): Promise<void>;
+    error(content: T): Promise<void>;
+}
 
-    success(message: string): Promise<void> {
-        return this.log(message, "Success");
-    }
-
-    warn(message: string): Promise<void> {
-        return this.log(message, "Warn");
-    }
-
-    error(message: string): Promise<void> {
-        return this.log(message, "Error");
-    }
-
-    private log(message: string, messageType: MessageType): Promise<void> {
-        if (this.loggerRepository) {
-            const options = { isDebug: this.isDebug };
-            return new LogMessageUseCase(this.loggerRepository)
-                .execute({ message: message, messageType: messageType }, options)
-                .toPromise();
-        } else {
-            throw new Error(`Logger not initialized properly. Please check configuration.`);
-        }
-    }
-
-    private async configProgramLogger(config: ProgramLoggerConfig): Promise<void> {
-        this.programRepository = new ProgramD2Repository();
-        const isConfigOk = await new CheckConfigProgramLoggerUseCase(this.programRepository)
-            .execute(config)
-            .toPromise();
-        if (isConfigOk) {
-            this.loggerRepository = new ProgramLoggerD2Repository(config);
-        } else {
-            throw new Error(
-                `Logger not initialized properly. Please check program and data elements configuration.`
-            );
-        }
-    }
-
-    private configConsoleLogger(): void {
-        this.loggerRepository = new ConsoleLoggerRepository();
+export async function initLogger<T>(config: LoggerConfig): Promise<Logger<T>> {
+    switch (config.type) {
+        case "program":
+            return ProgramLogger.create(config) as Promise<Logger<T>>;
+        case "trackerProgram":
+            return TrackerProgramLogger.create(config) as Promise<Logger<T>>;
+        case "console":
+        default:
+            return ConsoleLogger.create() as Promise<Logger<T>>;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ type LoggerType = {
     console: ConsoleLogger;
 };
 
-export async function initLogger<Config extends LoggerConfig>(
+async function initLogger<Config extends LoggerConfig>(
     config: Config
 ): Promise<LoggerType[Config["type"]]> {
     type Result = Promise<LoggerType[Config["type"]]>;
@@ -49,3 +49,5 @@ export async function initLogger<Config extends LoggerConfig>(
             return ConsoleLogger.create() as Result;
     }
 }
+
+export { ConsoleLogger, ProgramLogger, TrackerProgramLogger, initLogger };

--- a/src/loggers/ConsoleLogger.ts
+++ b/src/loggers/ConsoleLogger.ts
@@ -1,0 +1,44 @@
+import { Logger } from "..";
+import { MessageType } from "../domain/entities/Log";
+import { LoggerRepository } from "../domain/repositories/LoggerRepository";
+import { LogMessageUseCase } from "../domain/usecases/LogMessageUseCase";
+import { ConsoleLoggerRepository } from "../data/repositories/ConsoleLoggerRepository";
+
+export class ConsoleLogger implements Logger<string> {
+    private constructor(private loggerRepository: LoggerRepository) {}
+
+    static async create(): Promise<ConsoleLogger> {
+        const loggerRepository = new ConsoleLoggerRepository();
+        return new ConsoleLogger(loggerRepository);
+    }
+
+    debug(content: string): Promise<void> {
+        return this.log(content, "Debug");
+    }
+
+    info(content: string): Promise<void> {
+        return this.log(content, "Info");
+    }
+
+    success(content: string): Promise<void> {
+        return this.log(content, "Success");
+    }
+
+    warn(content: string): Promise<void> {
+        return this.log(content, "Warn");
+    }
+
+    error(content: string): Promise<void> {
+        return this.log(content, "Error");
+    }
+
+    private log(content: string, messageType: MessageType): Promise<void> {
+        if (this.loggerRepository) {
+            return new LogMessageUseCase(this.loggerRepository)
+                .execute({ message: content, messageType: messageType })
+                .toPromise();
+        } else {
+            throw new Error(`Logger not initialized properly. Please check configuration.`);
+        }
+    }
+}

--- a/src/loggers/ProgramLogger.ts
+++ b/src/loggers/ProgramLogger.ts
@@ -1,0 +1,57 @@
+import { Logger } from "..";
+import { MessageType } from "../domain/entities/Log";
+import { ProgramLoggerConfig } from "../domain/entities/LoggerConfig";
+import { LoggerRepository } from "../domain/repositories/LoggerRepository";
+import { CheckConfigProgramLoggerUseCase } from "../domain/usecases/CheckConfigProgramLoggerUseCase";
+import { LogMessageUseCase } from "../domain/usecases/LogMessageUseCase";
+import { ProgramD2Repository } from "../data/repositories/ProgramD2Repository";
+import { ProgramLoggerD2Repository } from "../data/repositories/ProgramLoggerD2Repository";
+
+export class ProgramLogger implements Logger<string> {
+    private constructor(private loggerRepository: LoggerRepository, private isDebug?: boolean) {}
+
+    static async create(config: ProgramLoggerConfig): Promise<ProgramLogger> {
+        const isConfigOk = await new CheckConfigProgramLoggerUseCase(new ProgramD2Repository())
+            .execute(config)
+            .toPromise();
+        if (isConfigOk) {
+            const loggerRepository = new ProgramLoggerD2Repository(config);
+            return new ProgramLogger(loggerRepository, config.debug);
+        } else {
+            throw new Error(
+                `Logger not initialized properly. Please check program and data elements configuration.`
+            );
+        }
+    }
+
+    debug(content: string): Promise<void> {
+        return this.log(content, "Debug");
+    }
+
+    info(content: string): Promise<void> {
+        return this.log(content, "Info");
+    }
+
+    success(content: string): Promise<void> {
+        return this.log(content, "Success");
+    }
+
+    warn(content: string): Promise<void> {
+        return this.log(content, "Warn");
+    }
+
+    error(content: string): Promise<void> {
+        return this.log(content, "Error");
+    }
+
+    private log(content: string, messageType: MessageType): Promise<void> {
+        if (this.loggerRepository) {
+            const options = { isDebug: this.isDebug };
+            return new LogMessageUseCase(this.loggerRepository)
+                .execute({ message: content, messageType: messageType }, options)
+                .toPromise();
+        } else {
+            throw new Error(`Logger not initialized properly. Please check configuration.`);
+        }
+    }
+}

--- a/src/loggers/TrackerProgramLogger.ts
+++ b/src/loggers/TrackerProgramLogger.ts
@@ -1,0 +1,71 @@
+import { Logger, TrackerProgramContent } from "..";
+import { MessageType, TrackerProgramLog } from "../domain/entities/Log";
+import { TrackerProgramLoggerConfig } from "../domain/entities/LoggerConfig";
+import { LoggerRepository } from "../domain/repositories/LoggerRepository";
+import { CheckConfigProgramLoggerUseCase } from "../domain/usecases/CheckConfigProgramLoggerUseCase";
+import { LogMessageUseCase } from "../domain/usecases/LogMessageUseCase";
+import { TrackerProgramD2Repository } from "../data/repositories/TrackerProgramD2Repository";
+import { TrackerProgramLoggerD2Repository } from "../data/repositories/TrackerProgramLoggerD2Repository";
+
+export class TrackerProgramLogger implements Logger<TrackerProgramContent> {
+    private constructor(private loggerRepository: LoggerRepository, private isDebug?: boolean) {}
+
+    static async create(config: TrackerProgramLoggerConfig): Promise<TrackerProgramLogger> {
+        const isConfigOk = await new CheckConfigProgramLoggerUseCase(
+            new TrackerProgramD2Repository()
+        )
+            .execute(config)
+            .toPromise();
+
+        if (isConfigOk) {
+            const loggerRepository = new TrackerProgramLoggerD2Repository(config);
+            return new TrackerProgramLogger(loggerRepository, config.debug);
+        } else {
+            throw new Error(
+                `Logger not initialized properly. Please check program and data elements configuration.`
+            );
+        }
+    }
+
+    debug(content: TrackerProgramContent): Promise<void> {
+        return this.log(content, "Debug");
+    }
+
+    info(content: TrackerProgramContent): Promise<void> {
+        return this.log(content, "Info");
+    }
+
+    success(content: TrackerProgramContent): Promise<void> {
+        return this.log(content, "Success");
+    }
+
+    warn(content: TrackerProgramContent): Promise<void> {
+        return this.log(content, "Warn");
+    }
+
+    error(content: TrackerProgramContent): Promise<void> {
+        return this.log(content, "Error");
+    }
+
+    private log(content: TrackerProgramContent, messageType: MessageType): Promise<void> {
+        if (this.loggerRepository) {
+            const options = { isDebug: this.isDebug };
+            const log = this.mapContentToLog(content, messageType);
+            return new LogMessageUseCase(this.loggerRepository).execute(log, options).toPromise();
+        } else {
+            throw new Error(`Logger not initialized properly. Please check configuration.`);
+        }
+    }
+
+    private mapContentToLog(
+        content: TrackerProgramContent,
+        messageType: MessageType
+    ): TrackerProgramLog {
+        const { config, messages } = content;
+        return {
+            config: config,
+            messages: messages,
+            messageType: messageType,
+        };
+    }
+}

--- a/src/scripts/cli.ts
+++ b/src/scripts/cli.ts
@@ -3,6 +3,7 @@ import { run, subcommands } from "cmd-ts";
 
 import * as programLogger from "./commands/programLogger";
 import * as consoleLogger from "./commands/consoleLogger";
+import * as trackerProgramLogger from "./commands/trackerProgramLogger";
 
 export function runCli() {
     const cliSubcommands = subcommands({
@@ -10,6 +11,7 @@ export function runCli() {
         cmds: {
             programLogger: programLogger.getCommand(),
             consoleLogger: consoleLogger.getCommand(),
+            trackerProgramLogger: trackerProgramLogger.getCommand(),
         },
     });
 

--- a/src/scripts/commands/consoleLogger.ts
+++ b/src/scripts/commands/consoleLogger.ts
@@ -1,6 +1,6 @@
 import { boolean, command, flag, option, string, subcommands } from "cmd-ts";
 import { AuthString, getD2ApiFromArgs } from "../common";
-import { initLogger } from "../..";
+import { ConsoleLogger, initLogger } from "../..";
 
 export function getCommand() {
     const consoleLogger = command({
@@ -25,7 +25,7 @@ export function getCommand() {
         },
         handler: async args => {
             try {
-                const logger = await initLogger({
+                const logger: ConsoleLogger = await initLogger({
                     type: "console",
                 });
 

--- a/src/scripts/commands/consoleLogger.ts
+++ b/src/scripts/commands/consoleLogger.ts
@@ -1,6 +1,6 @@
 import { boolean, command, flag, option, string, subcommands } from "cmd-ts";
 import { AuthString, getD2ApiFromArgs } from "../common";
-import { Logger } from "../..";
+import { initLogger } from "../..";
 
 export function getCommand() {
     const consoleLogger = command({
@@ -25,10 +25,10 @@ export function getCommand() {
         },
         handler: async args => {
             try {
-                const logger = new Logger();
-                logger.init({
+                const logger = await initLogger<string>({
                     type: "console",
                 });
+
                 logger.info("START: Getting DHIS2 instance info");
                 const api = getD2ApiFromArgs(args);
                 const info = await api.system.info.getData();

--- a/src/scripts/commands/consoleLogger.ts
+++ b/src/scripts/commands/consoleLogger.ts
@@ -25,7 +25,7 @@ export function getCommand() {
         },
         handler: async args => {
             try {
-                const logger = await initLogger<string>({
+                const logger = await initLogger({
                     type: "console",
                 });
 

--- a/src/scripts/commands/programLogger.ts
+++ b/src/scripts/commands/programLogger.ts
@@ -46,7 +46,7 @@ export function getCommand() {
         handler: async args => {
             const { url, auth, orgUnitId, programId, messageTypeId, messageId, debug } = args;
             try {
-                const logger = await initLogger<string>({
+                const logger = await initLogger({
                     type: "program",
                     debug: debug,
                     baseUrl: url,

--- a/src/scripts/commands/programLogger.ts
+++ b/src/scripts/commands/programLogger.ts
@@ -1,6 +1,6 @@
 import { boolean, command, flag, option, string, subcommands } from "cmd-ts";
 import { AuthString, getD2ApiFromArgs } from "../common";
-import { initLogger } from "../..";
+import { ProgramLogger, initLogger } from "../..";
 
 export function getCommand() {
     const programLogger = command({
@@ -46,7 +46,7 @@ export function getCommand() {
         handler: async args => {
             const { url, auth, orgUnitId, programId, messageTypeId, messageId, debug } = args;
             try {
-                const logger = await initLogger({
+                const logger: ProgramLogger = await initLogger({
                     type: "program",
                     debug: debug,
                     baseUrl: url,

--- a/src/scripts/commands/programLogger.ts
+++ b/src/scripts/commands/programLogger.ts
@@ -1,6 +1,6 @@
 import { boolean, command, flag, option, string, subcommands } from "cmd-ts";
 import { AuthString, getD2ApiFromArgs } from "../common";
-import { Logger } from "../..";
+import { initLogger } from "../..";
 
 export function getCommand() {
     const programLogger = command({
@@ -46,8 +46,7 @@ export function getCommand() {
         handler: async args => {
             const { url, auth, orgUnitId, programId, messageTypeId, messageId, debug } = args;
             try {
-                const logger = new Logger();
-                await logger.init({
+                const logger = await initLogger<string>({
                     type: "program",
                     debug: debug,
                     baseUrl: url,
@@ -59,7 +58,8 @@ export function getCommand() {
                         messageTypeId: messageTypeId,
                     },
                 });
-                logger.info("START: Getting DHIS2 instance info");
+
+                await logger.info("START: Getting DHIS2 instance info");
                 const api = getD2ApiFromArgs(args);
                 const info = await api.system.info.getData();
                 logger.success(JSON.stringify(info));

--- a/src/scripts/commands/trackerProgramLogger.ts
+++ b/src/scripts/commands/trackerProgramLogger.ts
@@ -90,6 +90,7 @@ export function getCommand() {
                         trackedEntityId: trackedEntityId,
                         programStageId: programStageId,
                         enrollmentId: enrollmentId,
+                        eventStatus: "COMPLETED",
                     },
                     messages: [{ id: messageId, value: JSON.stringify(info) }],
                 });

--- a/src/scripts/commands/trackerProgramLogger.ts
+++ b/src/scripts/commands/trackerProgramLogger.ts
@@ -1,6 +1,6 @@
 import { boolean, command, flag, option, optional, string, subcommands } from "cmd-ts";
 import { AuthString, getD2ApiFromArgs } from "../common";
-import { initLogger } from "../..";
+import { TrackerProgramLogger, initLogger } from "../..";
 
 export function getCommand() {
     const trackerProgramLogger = command({
@@ -66,7 +66,7 @@ export function getCommand() {
                 debug,
             } = args;
             try {
-                const logger = await initLogger({
+                const logger: TrackerProgramLogger = await initLogger({
                     type: "trackerProgram",
                     debug: debug,
                     baseUrl: url,

--- a/src/scripts/commands/trackerProgramLogger.ts
+++ b/src/scripts/commands/trackerProgramLogger.ts
@@ -1,0 +1,106 @@
+import { boolean, command, flag, option, optional, string, subcommands } from "cmd-ts";
+import { AuthString, getD2ApiFromArgs } from "../common";
+import { TrackerProgramContent, initLogger } from "../..";
+
+export function getCommand() {
+    const trackerProgramLogger = command({
+        name: "Tracker program Logger example",
+        description: "Log DHIS2 instance info in a program of DHIS2",
+        args: {
+            url: option({
+                type: string,
+                long: "url",
+                description: "http[s]://HOST:PORT",
+            }),
+            auth: option({
+                type: AuthString,
+                long: "auth",
+                description: "USERNAME:PASSWORD",
+            }),
+            trackerProgramId: option({
+                type: string,
+                long: "program",
+                description: "Tracker program Id where register the logs",
+            }),
+            trackedEntityId: option({
+                type: string,
+                long: "tracked-entity",
+                description: "Id of the tracked entity where to create the event",
+            }),
+            programStageId: option({
+                type: string,
+                long: "program-stage",
+                description: "Id of the program stage where to create the event",
+            }),
+            enrollmentId: option({
+                type: string,
+                long: "enrollment",
+                description: "Id of the enrollment where to create the event",
+            }),
+            messageId: option({
+                type: string,
+                long: "message",
+                description: "Data Element Id of the Data Value of the event to be logged",
+            }),
+            messageTypeId: option({
+                type: optional(string),
+                long: "types",
+                description: "Id of the data element which is the types of message",
+            }),
+            debug: flag({
+                type: boolean,
+                long: "debug",
+                description: "Option to print also logs in console",
+            }),
+        },
+        handler: async args => {
+            const {
+                url,
+                auth,
+                trackerProgramId,
+                trackedEntityId,
+                programStageId,
+                enrollmentId,
+                messageTypeId,
+                messageId,
+                debug,
+            } = args;
+            try {
+                const logger = await initLogger<TrackerProgramContent>({
+                    type: "trackerProgram",
+                    debug: debug,
+                    baseUrl: url,
+                    auth: auth,
+                    trackerProgramId: trackerProgramId,
+                    messageTypeId: messageTypeId,
+                });
+
+                logger.info({
+                    config: {
+                        trackedEntityId: trackedEntityId,
+                        programStageId: programStageId,
+                        enrollmentId: enrollmentId,
+                    },
+                    messages: [{ id: messageId, value: "START: Getting DHIS2 instance info" }],
+                });
+                const api = getD2ApiFromArgs(args);
+                const info = await api.system.info.getData();
+                logger.success({
+                    config: {
+                        trackedEntityId: trackedEntityId,
+                        programStageId: programStageId,
+                        enrollmentId: enrollmentId,
+                    },
+                    messages: [{ id: messageId, value: JSON.stringify(info) }],
+                });
+            } catch (e) {
+                console.error(e);
+            }
+        },
+    });
+
+    return subcommands({
+        name: "Tracker program Logger example",
+        cmds: { log: trackerProgramLogger },
+    });
+}

--- a/src/scripts/commands/trackerProgramLogger.ts
+++ b/src/scripts/commands/trackerProgramLogger.ts
@@ -1,6 +1,6 @@
 import { boolean, command, flag, option, optional, string, subcommands } from "cmd-ts";
 import { AuthString, getD2ApiFromArgs } from "../common";
-import { TrackerProgramContent, initLogger } from "../..";
+import { initLogger } from "../..";
 
 export function getCommand() {
     const trackerProgramLogger = command({
@@ -66,7 +66,7 @@ export function getCommand() {
                 debug,
             } = args;
             try {
-                const logger = await initLogger<TrackerProgramContent>({
+                const logger = await initLogger({
                     type: "trackerProgram",
                     debug: debug,
                     baseUrl: url,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [DQ: d2-logger to support Tracker Programs](https://app.clickup.com/t/8693q9x95) and [DQ: d2-logger to support writing in different DEs](https://app.clickup.com/t/8693q9yq0)

### :memo: Implementation

- [x] Change index instead of logger class now it's a function that initiates the logger and returns it
- [x] Create different classes for each type of logger
- [x] Add D2 repositories needed to support Tracker program as output
- [x] Add new script for testing tracker program and adapt others
- [x] Update README
- [x] Allow to log an array of Data Elements in tracker program

### :video_camera: Screenshots/Screen capture
[Screencast from 14-02-24 08:44:28.webm](https://github.com/EyeSeeTea/d2-logger/assets/49402898/657c4ea5-9c4c-4528-bf08-d3ab4e66745f)

### :fire: Notes to the tester
- Using script to just testing the logger (add corresponding `url`, `auth` and the ids needed. `message` is the Data Element Id of a Data Value of the event to be logged):
`yarn script-tracker-program-example --url "" --auth admin:district --program "" --tracked-entity "" --program-stage "" --enrollment "" --message "" --debug`

- Using yarn link to test logger in your app:
```bash
$ nvm use # Selects node in .nvmrc
$ yarn install
$ yarn build
$ cd build
$ yarn link
```

On another app:

```bash
$ yarn link "@eyeseetea/d2-logger"
```

