### PR TITLE
Update auth param to be Auth type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ There are three types of logger output:
         type: "program",
         debug: true,
         baseUrl: "https://play.dhis2.org/40.2.2",
-        auth: "admin:district",
+        auth: {
+            username: "admin",
+            password: "district",
+        },
         organisationUnitId: "", // Organisation unit Id where the program is registered
         programId: "", // Event program Id where register the logs as events
         dataElements: {
@@ -77,7 +80,10 @@ There are three types of logger output:
         type: "trackerProgram",
         debug: true,
         baseUrl: "https://play.dhis2.org/40.2.2",
-        auth: "admin:district",
+        auth: {
+            username: "admin",
+            password: "district",
+        },
         trackerProgramId: "", // Tracker program Id where register the logs as events
         messageTypeId: "", // Id of the data element which is the types of log
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyeseetea/d2-logger",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "DHIS2 library that allows a certain application to register logs as events in a DHIS2 event program, tracker program or simply display logs on the console.",
     "author": "EyeSeeTea team <info@eyeseetea.com>",
     "license": "GPL-3.0",


### PR DESCRIPTION
### :memo: Implementation
- Now auth param is and Auth type , so README file needs to update that info in the initLogger

```typescript
type Auth = {
    username: string;
    password: string;
};
``` 

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester
