### PR TITLE
add support v41 for enrollments endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyeseetea/d2-logger",
-    "version": "1.1.0",
+    "version": "1.1.0-beta.1",
     "description": "DHIS2 library that allows a certain application to register logs as events in a DHIS2 event program, tracker program or simply display logs on the console.",
     "author": "EyeSeeTea team <info@eyeseetea.com>",
     "license": "GPL-3.0",
@@ -61,5 +61,6 @@
         "vite": "^4.2.0",
         "vitest": "^0.34.6",
         "watch": "^1.0.2"
-    }
+    },
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eyeseetea/d2-logger",
-    "version": "1.1.0-beta.1",
+    "version": "1.2.0-beta.1",
     "description": "DHIS2 library that allows a certain application to register logs as events in a DHIS2 event program, tracker program or simply display logs on the console.",
     "author": "EyeSeeTea team <info@eyeseetea.com>",
     "license": "GPL-3.0",

--- a/src/data/repositories/TrackerProgramLoggerD2Repository.ts
+++ b/src/data/repositories/TrackerProgramLoggerD2Repository.ts
@@ -11,6 +11,7 @@ import {
 } from "../../domain/entities/Log";
 import { TrackerProgramLoggerConfig } from "../../domain/entities/LoggerConfig";
 import { LoggerRepository } from "../../domain/repositories/LoggerRepository";
+import { TrackerEnrollmentsResponse } from "@eyeseetea/d2-api/api/trackerEnrollments";
 
 const IMPORT_STRATEGY_CREATE = "CREATE";
 const TRACKER_IMPORT_JOB = "TRACKER_IMPORT_JOB";
@@ -80,7 +81,13 @@ export class TrackerProgramLoggerD2Repository implements LoggerRepository {
                 enrollment: enrollmentId,
             })
         ).flatMap(response => {
-            const orgUnitId = response.instances[0]?.orgUnit;
+            // Temporal fix while we wait for PR#156 to be merged in d2-api
+            // https://github.com/EyeSeeTea/d2-api/pull/156
+            const newResponse = response as TrackerEnrollmentsResponse & {
+                enrollments?: TrackerEnrollmentsResponse["instances"];
+            };
+            const instances = newResponse.instances || newResponse.enrollments;
+            const orgUnitId = instances[0]?.orgUnit;
             if (orgUnitId) {
                 return Future.success(orgUnitId);
             } else {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8697ct73j

### :memo: Implementation

In v41 the enrollments endpoint return the actual data in a `enrollments` array instead the `instances` property. This PR is a temporal fix while we wait [this PR](https://github.com/EyeSeeTea/d2-api/pull/156) to be merged in d2-api and because updating d2-api from v14 (current version in this project) to v16 is breaking other things in the library.

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

@Ramon-Jimenez can you please help me publishing a new beta version so I can install it in the data-quality repo.

#8697ct73j