### PR TITLE
Improve error handling to no stop node running if any error in logger

### DIFF
--- a/src/data/repositories/ProgramLoggerD2Repository.ts
+++ b/src/data/repositories/ProgramLoggerD2Repository.ts
@@ -5,6 +5,7 @@ import { Id } from "../../domain/entities/Base";
 import { DefaultLog } from "../../domain/entities/Log";
 import { ProgramLoggerConfig } from "../../domain/entities/LoggerConfig";
 import { LoggerRepository } from "../../domain/repositories/LoggerRepository";
+import { getErrorMessage } from "../../loggers/utils/getErrorMessage";
 
 const IMPORT_STRATEGY_CREATE = "CREATE";
 const TRACKER_IMPORT_JOB = "TRACKER_IMPORT_JOB";
@@ -38,9 +39,9 @@ export class ProgramLoggerD2Repository implements LoggerRepository {
             .toPromise()
             .catch(error => {
                 throw new Error(
-                    `Error fetching program stage of program with id ${config.programId}: ${
-                        error instanceof Error ? error.message : String(error)
-                    }`
+                    `Error fetching program stage of program with id ${
+                        config.programId
+                    }: ${getErrorMessage(error)}`
                 );
             });
 

--- a/src/data/repositories/ProgramLoggerD2Repository.ts
+++ b/src/data/repositories/ProgramLoggerD2Repository.ts
@@ -34,7 +34,16 @@ export class ProgramLoggerD2Repository implements LoggerRepository {
         const d2ProgramStage = await ProgramLoggerD2Repository.getProgramStage(
             api,
             config.programId
-        ).toPromise();
+        )
+            .toPromise()
+            .catch(error => {
+                throw new Error(
+                    `Error fetching program stage of program with id ${config.programId}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`
+                );
+            });
+
         return new ProgramLoggerD2Repository(config, d2ProgramStage);
     }
 

--- a/src/loggers/ProgramLogger.ts
+++ b/src/loggers/ProgramLogger.ts
@@ -9,6 +9,7 @@ import { ProgramLoggerD2Repository } from "../data/repositories/ProgramLoggerD2R
 import { BatchLogMessageUseCase } from "../domain/usecases/BatchLogMessageUseCase";
 import { BatchLogContent } from "../domain/entities/BatchLogContent";
 import { mapContentToLog } from "./utils/mapContentToLog";
+import { logErrorInConsole } from "./utils/logErrorInConsole";
 
 // TODO: homogenize the use of Promises or Futures
 export class ProgramLogger implements Logger<string> {
@@ -17,7 +18,15 @@ export class ProgramLogger implements Logger<string> {
     static async create(config: ProgramLoggerConfig): Promise<ProgramLogger> {
         const isConfigOk = await new CheckConfigProgramLoggerUseCase(new ProgramD2Repository())
             .execute(config)
-            .toPromise();
+            .toPromise()
+            .catch(error => {
+                throw new Error(
+                    `Error checking program configuration for program with id ${
+                        config.programId
+                    }: ${error instanceof Error ? error.message : String(error)}`
+                );
+            });
+
         if (isConfigOk) {
             const loggerRepository = await ProgramLoggerD2Repository.init(config);
             return new ProgramLogger(loggerRepository, config.debug);
@@ -51,12 +60,24 @@ export class ProgramLogger implements Logger<string> {
     batchLog(content: BatchLogContent): Promise<void> {
         const options = { isDebug: this.isDebug };
         const logs = content.map(content => mapContentToLog(content.content, content.messageType));
-        return new BatchLogMessageUseCase(this.loggerRepository).execute(logs, options).toPromise();
+
+        return new BatchLogMessageUseCase(this.loggerRepository)
+            .execute(logs, options)
+            .toPromise()
+            .catch((error: unknown) => {
+                logErrorInConsole(error, "Error while processing batch logs");
+            });
     }
 
     private log(content: string, messageType: MessageType): Promise<void> {
         const options = { isDebug: this.isDebug };
         const log = mapContentToLog(content, messageType);
-        return new LogMessageUseCase(this.loggerRepository).execute(log, options).toPromise();
+
+        return new LogMessageUseCase(this.loggerRepository)
+            .execute(log, options)
+            .toPromise()
+            .catch((error: unknown) => {
+                logErrorInConsole(error, "Error while logging message");
+            });
     }
 }

--- a/src/loggers/ProgramLogger.ts
+++ b/src/loggers/ProgramLogger.ts
@@ -10,6 +10,7 @@ import { BatchLogMessageUseCase } from "../domain/usecases/BatchLogMessageUseCas
 import { BatchLogContent } from "../domain/entities/BatchLogContent";
 import { mapContentToLog } from "./utils/mapContentToLog";
 import { logErrorInConsole } from "./utils/logErrorInConsole";
+import { getErrorMessage } from "./utils/getErrorMessage";
 
 // TODO: homogenize the use of Promises or Futures
 export class ProgramLogger implements Logger<string> {
@@ -23,7 +24,7 @@ export class ProgramLogger implements Logger<string> {
                 throw new Error(
                     `Error checking program configuration for program with id ${
                         config.programId
-                    }: ${error instanceof Error ? error.message : String(error)}`
+                    }: ${getErrorMessage(error)}`
                 );
             });
 

--- a/src/loggers/TrackerProgramLogger.ts
+++ b/src/loggers/TrackerProgramLogger.ts
@@ -7,6 +7,7 @@ import { LogMessageUseCase } from "../domain/usecases/LogMessageUseCase";
 import { TrackerProgramD2Repository } from "../data/repositories/TrackerProgramD2Repository";
 import { TrackerProgramLoggerD2Repository } from "../data/repositories/TrackerProgramLoggerD2Repository";
 import { BatchLogContent } from "../domain/entities/BatchLogContent";
+import { logErrorInConsole } from "./utils/logErrorInConsole";
 
 // TODO: homogenize the use of Promises or Futures
 export class TrackerProgramLogger implements Logger<TrackerProgramContent> {
@@ -17,7 +18,14 @@ export class TrackerProgramLogger implements Logger<TrackerProgramContent> {
             new TrackerProgramD2Repository()
         )
             .execute(config)
-            .toPromise();
+            .toPromise()
+            .catch(error => {
+                throw new Error(
+                    `Error checking program configuration for program with id ${
+                        config.trackerProgramId
+                    }: ${error instanceof Error ? error.message : String(error)}`
+                );
+            });
 
         if (isConfigOk) {
             const loggerRepository = new TrackerProgramLoggerD2Repository(config);
@@ -57,7 +65,12 @@ export class TrackerProgramLogger implements Logger<TrackerProgramContent> {
     private log(content: TrackerProgramContent, messageType: MessageType): Promise<void> {
         const options = { isDebug: this.isDebug };
         const log = this.mapContentToLog(content, messageType);
-        return new LogMessageUseCase(this.loggerRepository).execute(log, options).toPromise();
+        return new LogMessageUseCase(this.loggerRepository)
+            .execute(log, options)
+            .toPromise()
+            .catch((error: unknown) => {
+                logErrorInConsole(error, "Error while logging message");
+            });
     }
 
     private mapContentToLog(

--- a/src/loggers/TrackerProgramLogger.ts
+++ b/src/loggers/TrackerProgramLogger.ts
@@ -8,6 +8,7 @@ import { TrackerProgramD2Repository } from "../data/repositories/TrackerProgramD
 import { TrackerProgramLoggerD2Repository } from "../data/repositories/TrackerProgramLoggerD2Repository";
 import { BatchLogContent } from "../domain/entities/BatchLogContent";
 import { logErrorInConsole } from "./utils/logErrorInConsole";
+import { getErrorMessage } from "./utils/getErrorMessage";
 
 // TODO: homogenize the use of Promises or Futures
 export class TrackerProgramLogger implements Logger<TrackerProgramContent> {
@@ -23,7 +24,7 @@ export class TrackerProgramLogger implements Logger<TrackerProgramContent> {
                 throw new Error(
                     `Error checking program configuration for program with id ${
                         config.trackerProgramId
-                    }: ${error instanceof Error ? error.message : String(error)}`
+                    }: ${getErrorMessage(error)}`
                 );
             });
 

--- a/src/loggers/utils/getErrorMessage.ts
+++ b/src/loggers/utils/getErrorMessage.ts
@@ -1,0 +1,3 @@
+export function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/src/loggers/utils/logErrorInConsole.ts
+++ b/src/loggers/utils/logErrorInConsole.ts
@@ -1,0 +1,5 @@
+export function logErrorInConsole(error: unknown, contextMessage: string): void {
+    const date = new Date().toISOString();
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`[ERROR] [${date}] (d2-logger) ${contextMessage}: ${errorMessage}\n`);
+}

--- a/src/loggers/utils/logErrorInConsole.ts
+++ b/src/loggers/utils/logErrorInConsole.ts
@@ -1,5 +1,7 @@
+import { getErrorMessage } from "./getErrorMessage";
+
 export function logErrorInConsole(error: unknown, contextMessage: string): void {
     const date = new Date().toISOString();
-    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorMessage = getErrorMessage(error);
     console.error(`[ERROR] [${date}] (d2-logger) ${contextMessage}: ${errorMessage}\n`);
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869a73yk3 [Error in glass recalculations script: stops if d2-logger error](https://app.clickup.com/t/869a73yk3)

### :memo: Implementation
- if an error occurs, print it on console. Previously, if a script that used the logger was executed, it would stop if any error while logging.
- Improve some error messages
- throw error only while configuring logger

### :video_camera: Screenshots/Screen capture

<img width="1001" height="168" alt="Screenshot from 2025-09-05 13-05-35" src="https://github.com/user-attachments/assets/50fdd08f-243f-4bdd-809f-e72f8213c597" />

### :fire: Notes to the tester
