### PR TITLE
mac commands need to have the modifiers after the command

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,7 +4,7 @@ set -e -u -o pipefail
 version=$(cat package.json | jq -r '.version')
 publish_opts=$(if echo "$version" | grep -q beta; then echo "--tag beta"; fi)
 
-rm build -rf
+rm -rf build 
 yarn build
 yarn publish $publish_opts --new-version "$version" build/
 


### PR DESCRIPTION
just changing some rm build -rf to rm -rf build